### PR TITLE
Add GITHUB_TOKEN environment variable to PR commenter steps in workflow

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -138,6 +138,8 @@ runs:
     - name: PR Format
       if: github.event_name == 'pull_request'
       uses: jimdo/terraform-pr-commenter@v1.6.1
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
       with:
         commenter_type: fmt
         commenter_input: ${{ format('{0}{1}', steps.fmt.outputs.stdout, steps.fmt.outputs.stderr) }}
@@ -152,6 +154,8 @@ runs:
     - name: PR Init
       if: github.event_name == 'pull_request'
       uses: jimdo/terraform-pr-commenter@v1.6.1
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
       with:
         commenter_type: init
         commenter_input: ${{ format('{0}{1}', steps.init.outputs.stdout, steps.init.outputs.stderr) }}
@@ -166,6 +170,8 @@ runs:
     - name: PR Validate
       if: github.event_name == 'pull_request'
       uses: jimdo/terraform-pr-commenter@v1.6.1
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
       with:
         commenter_type: validate
         commenter_input: ${{ format('{0}{1}', steps.validate.outputs.stdout, steps.validate.outputs.stderr) }}
@@ -183,6 +189,8 @@ runs:
     - name: PR Plan (Deploy)
       if: ${{ inputs.plan_mode == 'deploy' && github.event_name == 'pull_request' }}
       uses: jimdo/terraform-pr-commenter@v1.6.1
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
       with:
         commenter_type: plan
         commenter_input: ${{ format('{0}{1}', steps.deploy_plan.outputs.stdout, steps.deploy_plan.outputs.stderr) }}
@@ -201,6 +209,8 @@ runs:
     - name: PR Plan (Destroy)
       if: ${{ inputs.plan_mode != 'deploy' && github.event_name == 'pull_request' }}
       uses: jimdo/terraform-pr-commenter@v1.6.1
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
       with:
         commenter_type: plan
         commenter_input: ${{ format('{0}{1}', steps.destroy_plan.outputs.stdout, steps.destroy_plan.outputs.stderr) }}


### PR DESCRIPTION
This pull request includes updates to the `action.yml` file to ensure that the `GITHUB_TOKEN` environment variable is available for various steps in the workflow. The changes primarily focus on adding the `env` key with the `GITHUB_TOKEN` value to multiple steps.

Environment variable additions:

* Added `env` key with `GITHUB_TOKEN` to the `PR Format` step.
* Added `env` key with `GITHUB_TOKEN` to the `PR Init` step.
* Added `env` key with `GITHUB_TOKEN` to the `PR Validate` step.
* Added `env` key with `GITHUB_TOKEN` to the `PR Plan (Deploy)` step.
* Added `env` key with `GITHUB_TOKEN` to the `PR Plan (Destroy)` step.

Closes #3 