### PR TITLE
Replacing PR Commenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ This GitHub Action runs `terraform plan` with an Azure Remote Backend and upload
 - `arm_subscription_id` - Subscription ID of the Azure Service Principal for authentication.
 - `github_token` - GitHub token for posting comments on pull requests. Specify a valid GitHub token.
 
+## Actions Used
+
+| Action                          | Version   | Purpose                                                                 |
+|---------------------------------|-----------|-------------------------------------------------------------------------|
+| `actions/checkout`              | `v4.2.0`  | Checks out the repository to the runner.                                |
+| `hashicorp/setup-terraform`     | `v3.1.2`  | Sets up Terraform CLI in the GitHub Actions runner.                     |
+| `jimdo/terraform-pr-commenter`  | `v1.6.1`  | Posts comments on pull requests with the results of Terraform commands. |
+| `liatrio/terraform-change-pr-commenter` | `v1.7.1` | Posts comments on pull requests with the Terraform plan changes, in addition to the results of Terraform plan within workflow summary. |
+| `actions/upload-artifact`       | `v4.4.3`  | Uploads artifacts to be used in subsequent workflow steps.              |
+
 ## Usage Examples
 
 ### Installation

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This GitHub Action runs `terraform plan` with an Azure Remote Backend and upload
 | `hashicorp/setup-terraform`     | `v3.1.2`  | Sets up Terraform CLI in the GitHub Actions runner.                     |
 | `jimdo/terraform-pr-commenter`  | `v1.6.1`  | Posts comments on pull requests with the results of Terraform commands. |
 | `liatrio/terraform-change-pr-commenter` | `v1.7.1` | Posts comments on pull requests with the Terraform plan changes, in addition to the results of Terraform plan within workflow summary. |
-| `actions/upload-artifact`       | `v4.4.3`  | Uploads artifacts to be used in subsequent workflow steps.              |
+| `actions/upload-artifact`       | `v4.5.0`  | Uploads artifacts to be used in subsequent workflow steps.              |
 
 ## Usage Examples
 

--- a/action.yml
+++ b/action.yml
@@ -186,15 +186,26 @@ runs:
         terraform show -json -no-color deploy_plan.tfplan > deploy_plan.json
       working-directory: ${{ inputs.path }}
 
+    # - name: PR Plan (Deploy)
+    #   if: ${{ inputs.plan_mode == 'deploy' && github.event_name == 'pull_request' }}
+    #   uses: jimdo/terraform-pr-commenter@v1.6.1
+    #   env:
+    #     GITHUB_TOKEN: ${{ inputs.github_token }}
+    #   with:
+    #     commenter_type: plan
+    #     commenter_input: ${{ format('{0}{1}', steps.deploy_plan.outputs.stdout, steps.deploy_plan.outputs.stderr) }}
+    #     commenter_exitcode: ${{ steps.deploy_plan.outputs.exitcode }}
+    #   continue-on-error: true
     - name: PR Plan (Deploy)
       if: ${{ inputs.plan_mode == 'deploy' && github.event_name == 'pull_request' }}
-      uses: jimdo/terraform-pr-commenter@v1.6.1
+      uses: liatrio/terraform-change-pr-commenter@v1.7.1
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       with:
-        commenter_type: plan
-        commenter_input: ${{ format('{0}{1}', steps.deploy_plan.outputs.stdout, steps.deploy_plan.outputs.stderr) }}
-        commenter_exitcode: ${{ steps.deploy_plan.outputs.exitcode }}
+        json-file: ${{ inputs.path }}/deploy_plan.json
+        include-plan-job-summary: true
+        include-workflow-link: true
+        hide-previous-comments: true
       continue-on-error: true
 
     - name: Terraform Plan (Destroy)

--- a/action.yml
+++ b/action.yml
@@ -205,6 +205,7 @@ runs:
         json-file: ${{ inputs.path }}/deploy_plan.json
         include-plan-job-summary: true
         include-workflow-link: true
+        expand-comment: true
         hide-previous-comments: true
       continue-on-error: true
 

--- a/action.yml
+++ b/action.yml
@@ -186,16 +186,6 @@ runs:
         terraform show -json -no-color deploy_plan.tfplan > deploy_plan.json
       working-directory: ${{ inputs.path }}
 
-    # - name: PR Plan (Deploy)
-    #   if: ${{ inputs.plan_mode == 'deploy' && github.event_name == 'pull_request' }}
-    #   uses: jimdo/terraform-pr-commenter@v1.6.1
-    #   env:
-    #     GITHUB_TOKEN: ${{ inputs.github_token }}
-    #   with:
-    #     commenter_type: plan
-    #     commenter_input: ${{ format('{0}{1}', steps.deploy_plan.outputs.stdout, steps.deploy_plan.outputs.stderr) }}
-    #     commenter_exitcode: ${{ steps.deploy_plan.outputs.exitcode }}
-    #   continue-on-error: true
     - name: PR Plan (Deploy)
       if: ${{ inputs.plan_mode == 'deploy' && github.event_name == 'pull_request' }}
       uses: liatrio/terraform-change-pr-commenter@v1.7.1
@@ -219,14 +209,16 @@ runs:
       working-directory: ${{ inputs.path }}
 
     - name: PR Plan (Destroy)
-      if: ${{ inputs.plan_mode != 'deploy' && github.event_name == 'pull_request' }}
-      uses: jimdo/terraform-pr-commenter@v1.6.1
+      if: ${{ inputs.plan_mode == 'destroy' && github.event_name == 'pull_request' }}
+      uses: liatrio/terraform-change-pr-commenter@v1.7.1
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       with:
-        commenter_type: plan
-        commenter_input: ${{ format('{0}{1}', steps.destroy_plan.outputs.stdout, steps.destroy_plan.outputs.stderr) }}
-        commenter_exitcode: ${{ steps.destroy_plan.outputs.exitcode }}
+        json-file: ${{ inputs.path }}/destroy_plan.json
+        include-plan-job-summary: true
+        include-workflow-link: true
+        expand-comment: true
+        hide-previous-comments: true
       continue-on-error: true
 
     - name: Compress Terraform Plan Artifacts

--- a/action.yml
+++ b/action.yml
@@ -228,7 +228,7 @@ runs:
       working-directory: ${{ inputs.path }}
 
     - name: Upload Plan Artifact
-      uses: actions/upload-artifact@v4.4.3
+      uses: actions/upload-artifact@v4.5.0
       with:
         name: "${{ inputs.plan_mode }}-${{ inputs.tf_state_file }}"
         path: "${{ inputs.path }}/${{ inputs.plan_mode }}${{ inputs.tf_state_file }}.zip"


### PR DESCRIPTION
This pull request includes updates to the GitHub Action workflow for running Terraform plans with an Azure Remote Backend. The changes focus on updating the actions used and improving the commenting process on pull requests.

### Updates to GitHub Actions:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R47-R56): Added a table listing the actions used in the workflow, including `actions/checkout`, `hashicorp/setup-terraform`, `jimdo/terraform-pr-commenter`, `liatrio/terraform-change-pr-commenter`, and `actions/upload-artifact`.

### Improvements to PR Commenting:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L191-R199): Updated the action used for posting comments on pull requests from `jimdo/terraform-pr-commenter@v1.6.1` to `liatrio/terraform-change-pr-commenter@v1.7.1` for both deploy and destroy plans. Added new parameters to include plan job summary, workflow link, expand comments, and hide previous comments. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L191-R199) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L210-R221)

### Artifact Upload:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L227-R231): Updated the `actions/upload-artifact` action from version `v4.4.3` to `v4.5.0`.